### PR TITLE
Add dependencies to fix tests.

### DIFF
--- a/test/platformio.ini
+++ b/test/platformio.ini
@@ -17,5 +17,7 @@ test_speed = 74880  ; Setting to 74880 removed garbled output when testing
 lib_deps =
   TestFlipDotMatrix ; Added manually because PIO wouldn't compile with symlink (but would with file://)
   Unity
+  Adafruit GFX Library
+  Adafruit BusIO
   symlink://../     ; It's better to use a symlink for development
                     ; so that the latest library changes are always pulled in


### PR DESCRIPTION
It doesn't look like PIO pulls in the dependencies from `library.properties` so they're unfortunately hardcoded here.